### PR TITLE
correct warning level for WATCOM

### DIFF
--- a/src/lang.l
+++ b/src/lang.l
@@ -88,7 +88,7 @@ static struct Language {
    * Warning! W202:  Symbol 'yy_fatal_error' has been defined, but not referenced.
    * But it does not work.
    */
-  #pragma warning 202 10
+  #pragma warning 202 5
 
 #endif
 


### PR DESCRIPTION
valid warning level is 0-4 and level 5 is for disabling warning
it is checked for Open Watcom 2.0