### PR TITLE
correct WATCOM 64-bit type usage

### DIFF
--- a/src/wattcp.h
+++ b/src/wattcp.h
@@ -72,7 +72,7 @@
   typedef long long           int64;
   #define HAVE_UINT64
 
-#elif defined(__WATCOMC__) && defined(__WATCOM_INT64__) && !(defined(__SMALL__) || defined(__LARGE__))
+#elif defined(__WATCOMC__) && defined(__WATCOM_INT64__)
   typedef unsigned __int64 uint64;
   typedef __int64          int64;
   #define HAVE_UINT64


### PR DESCRIPTION
64-bit type is defined for all WATCOM compilers and it doesn't depend on memory model etc.