### PR TITLE
fix a bug in WATCOM options

### DIFF
--- a/src/makefile.all
+++ b/src/makefile.all
@@ -493,7 +493,7 @@ MAKEFIL = watcom_f.mak
 
 @elifdef WIN32
 CC       = wcc386
-CFLAGS   = -mf -3r -zm -zw -bd -bm -d3 -zlf -bt=nt -fp6 -oilrtfm -zri
+CFLAGS   = -mf -3r -zm -bd -bm -d3 -zlf -bt=nt -fp6 -oilrtfm -zri
 AFLAGS   = -bt=nt -3s -dDOSX
 LDFLAGS  = system nt dll
 TARGET   = ..\lib\wattcpww.lib ..\lib\wattcpww_imp.lib


### PR DESCRIPTION
-zw option is for Windows 3.x applications
it create `__WINDOWS__` macro which  overwrite `__NT__` macro and completely confuse Windows header files and code.
This option need not be used for `WIN32` API