### PR TITLE
add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+* text=auto
+
+.bin binary
+.exe binary
+.EXE binary
+.ico binary


### PR DESCRIPTION
it is added to ensure text files are saved into git repository with normalized end-of-line (LF only)
it ensure proper EOL for text files on each platform when is read from repository.
On Windows EOL is CR/LF and on Linux it is LF.
Explicitly specify binary files even if git should recognize it, it prevent problem if git do wrong decision.