### PR TITLE
DJGPP specific: include io.h for filelength declaration.

### DIFF
--- a/src/misc.c
+++ b/src/misc.c
@@ -19,6 +19,10 @@
   #include <init.h>  /* _mwlsl(), _msgetcs() */
 #endif
 
+#if defined(__DJGPP__)
+  #include <io.h>  /* filelength() */
+#endif
+
 #if defined(WIN32) || defined(_WIN32) || defined(WIN64) || defined(__CYGWIN__)
   #include <io.h>
   #include <fcntl.h>


### PR DESCRIPTION
Pacify compiler.