### PR TITLE
Provide defintion of SHUT_RD, SHUT_WR and SHUT_RDWR macros in canonic…

### DIFF
--- a/inc/sys/socket.h
+++ b/inc/sys/socket.h
@@ -68,6 +68,18 @@
  * Definitions related to sockets: types, address families, options.
  */
 
+/* The following constants should be used for the second parameter,
+   the "how" field, of `shutdown'.  */
+enum
+{
+  SHUT_RD = 0,          /* Further receives are disallowed */
+#define SHUT_RD         SHUT_RD
+  SHUT_WR,              /* Further sends are disallowed */
+#define SHUT_WR         SHUT_WR
+  SHUT_RDWR             /* Further sends and receives are disallowed */
+#define SHUT_RDWR       SHUT_RDWR
+};
+
 /*
  * This is used instead of -1, since the socket type is signed.
  */

--- a/src/shutdown.c
+++ b/src/shutdown.c
@@ -39,10 +39,6 @@
 
 #if defined(USE_BSD_API)
 
-#define SHUT_RD   0    /* Further receives are disallowed */
-#define SHUT_WR   1    /* Further sends are disallowed */
-#define SHUT_RDWR 2    /* Further sends and receives are disallowed */
-
 int W32_CALL shutdown (int s, int how)
 {
   Socket *socket = _socklist_find (s);


### PR DESCRIPTION
Hello,

I am trying to make a DJGPP port of openssl 1.1.1m using the current repository
code of WATT-32 and I have observed that the macros SHUT_RD, SHUT_WR and
SHUT_RDWR are defined in src/shutdown.c instead of their canonical place.
In my linux system and in OpenBSD they are defined in sys/socket as enum
and macros.
I would propose the patch below but feel free to discard it and to implement
it as you like.

Regards,
Juan M. Guerrero
