### PR TITLE
Cross-compilation improvements

### DIFF
--- a/appveyor-script.bat
+++ b/appveyor-script.bat
@@ -87,7 +87,7 @@ set MINGW64=%APPVEYOR_BUILD_FOLDER_UNIX%
 :: 7z can create only 1 level of missing directories. So a '%CI_ROOT%\djgpp' will not work
 ::
 set DJGPP=%APPVEYOR_BUILD_FOLDER_UNIX%/CI-temp
-set DJ_PREFIX=%DJGPP%/bin/i586-pc-msdosdjgpp-
+set DJGPP_PREFIX=%DJGPP%/bin/i586-pc-msdosdjgpp
 
 ::
 :: Set env-var for building with Watcom 2.0

--- a/appveyor-script.py
+++ b/appveyor-script.py
@@ -195,7 +195,7 @@ def get_env_vars_common():
   #
   if builder == 'djgpp':
     env_var['DJGPP']     = env_var['CI_ROOT'].replace ('\\','/')
-    env_var['DJ_PREFIX'] = env_var['DJGPP'] + '/bin/i586-pc-msdosdjgpp-'
+    env_var['DJGPP_PREFIX'] = env_var['DJGPP'] + '/bin/i586-pc-msdosdjgpp'
 
   if builder == 'watcom':
     env_var['WATCOM']      = env_var['CI_ROOT']

--- a/bin/djcommon.mak
+++ b/bin/djcommon.mak
@@ -13,26 +13,23 @@
 .PHONY:    check_src check_exe check_gcc
 
 #
-# If building on Windows, the '$(BIN_PREFIX)gcc' should become something
-# like 'f:/gv/djgpp/bin/i586-pc-msdosdjgpp-gcc'.
+# If building on Windows or Linux, '$(DJGPP_PREFIX)-gcc' should become
+# something like 'i586-pc-msdosdjgpp-gcc' or a full path like
+# 'f:/gv/djgpp/bin/i586-pc-msdosdjgpp-gcc'.
 #
 # If building on plain old DOS, it is simply 'gcc' which 'make' should
 # find on %PATH.
 #
-ifeq ($(OS),Windows_NT)
-  ifeq ($(DJ_PREFIX),)
-    $(error Define a $(DJ_PREFIX) to point to the ROOT of the djgpp cross compiler).
-  endif
-
-  BIN_PREFIX ?= $(DJ_PREFIX)
-
-  #
-  # In case %DJDIR is not set under Windows. Why would it exist?
-  #
-  DJDIR ?= e:/djgpp
-else
-  BIN_PREFIX =
+ifneq ($(DJGPP_PREFIX),)
+  BIN_PREFIX = $(DJGPP_PREFIX)-
+else ifeq ($(OS),Windows_NT)
+  $(error Define a DJGPP_PREFIX to invoke the djgpp cross compiler).
 endif
+
+#
+# In case %DJDIR is not set under Windows. Why would it exist?
+#
+DJDIR ?= e:/djgpp
 
 #
 # Override any Unix-like SHELL set in environment or djgpp.env

--- a/bin/djgpp_win.mak
+++ b/bin/djgpp_win.mak
@@ -31,26 +31,23 @@ INC_DIR = ../inc
 WATTLIB = ../lib/libwatt.a
 
 #
-# If building on Windows, the '$(BIN_PREFIX)gcc' should become something
-# like 'f:/gv/djgpp/bin/i586-pc-msdosdjgpp-gcc'.
+# If building on Windows or Linux, '$(DJGPP_PREFIX)-gcc' should become
+# something like 'i586-pc-msdosdjgpp-gcc' or a full path like
+# 'f:/gv/djgpp/bin/i586-pc-msdosdjgpp-gcc'.
 #
 # If building on plain old DOS, it is simply 'gcc' which 'make' should
 # find on %PATH.
 #
-ifeq ($(OS),Windows_NT)
-  ifeq ($(DJ_PREFIX),)
-    $(error Define a $(DJ_PREFIX) to point to the ROOT of the djgpp cross compiler).
-  endif
-
-  BIN_PREFIX ?= $(DJ_PREFIX)
-
-  #
-  # In case %DJDIR is not set under Windows. Why would it exist?
-  #
-  DJDIR ?= e:/djgpp
-else
-  BIN_PREFIX =
+ifneq ($(DJGPP_PREFIX),)
+  BIN_PREFIX = $(DJGPP_PREFIX)-
+else ifeq ($(OS),Windows_NT)
+  $(error Define a DJGPP_PREFIX to invoke the djgpp cross compiler).
 endif
+
+#
+# In case %DJDIR is not set under Windows. Why would it exist?
+#
+DJDIR ?= e:/djgpp
 
 CC      =  $(BIN_PREFIX)gcc
 CFLAGS  = -Wall -W -Wno-sign-compare -g -O2 -I$(INC_DIR)

--- a/src/configur.bat
+++ b/src/configur.bat
@@ -157,7 +157,9 @@ goto next
 :djgpp
 ::
 echo Generating DJGPP makefile, directory, errnos and dependencies
-%MKMAKE% -o djgpp.mak -d build\djgpp makefile.all DJGPP FLAT
+echo #                                                      > djgpp.mak
+if not %DJGPP_PREFIX%.==. echo BIN_PREFIX = %DJGPP_PREFIX%->> djgpp.mak
+%MKMAKE% -d build\djgpp makefile.all DJGPP FLAT            >> djgpp.mak
 %MKDEP%  -s.o -p$(OBJDIR)/ *.c *.h   > build\djgpp\watt32.dep
 echo neterr.c: build/djgpp/syserr.c >> build\djgpp\watt32.dep
 

--- a/src/configur.sh
+++ b/src/configur.sh
@@ -21,7 +21,14 @@
 #
 # target triplet for cross-djgpp toolchain:
 #
-DJGPP_PREFIX="i586-pc-msdosdjgpp"
+if [ -z "$DJGPP_PREFIX" ]; then
+  for i in i{3..7}86-pc-msdosdjgpp; do
+    if which $i-gcc 2>&1 > /dev/null; then
+      DJGPP_PREFIX=$i
+      break
+    fi
+  done
+fi
 
 #
 # target triplet for cross-win64 toolchain, MinGW-w64:
@@ -76,8 +83,9 @@ usage ()
 #
 gen_djgpp ()
 {
-  echo "Generating DJGPP makefile, directory, errnos and dependencies"
-  ../util/linux/mkmake -o djgpp.mak -d              build/djgpp makefile.all DJGPP
+  echo "Generating DJGPP makefile, directory and dependencies"
+  echo "BIN_PREFIX = $DJGPP_PREFIX-" > djgpp.mak
+  ../util/linux/mkmake -d build/djgpp makefile.all DJGPP >> djgpp.mak
   ../util/linux/mkdep -s.o -p\$\(OBJDIR\)/ *.[ch] > build/djgpp/watt32.dep
   echo "neterr.c: build/djgpp/syserr.c"          >> build/djgpp/watt32.dep
 

--- a/src/configur.sh
+++ b/src/configur.sh
@@ -19,6 +19,15 @@
 #
 
 #
+# detect which utility programs to use
+#
+case $(uname) in
+MINGW*|MSYS*) util_dir=../util/win32 ;;
+*)            util_dir=../util/linux ;;
+# non-linux users will need to recompile util/linux/* for their platform.
+esac
+
+#
 # target triplet for cross-djgpp toolchain:
 #
 if [ -z "$DJGPP_PREFIX" ]; then
@@ -85,8 +94,8 @@ gen_djgpp ()
 {
   echo "Generating DJGPP makefile, directory and dependencies"
   echo "BIN_PREFIX = $DJGPP_PREFIX-" > djgpp.mak
-  ../util/linux/mkmake -d build/djgpp makefile.all DJGPP >> djgpp.mak
-  ../util/linux/mkdep -s.o -p\$\(OBJDIR\)/ *.[ch] > build/djgpp/watt32.dep
+  $util_dir/mkmake -d build/djgpp makefile.all DJGPP >> djgpp.mak
+  $util_dir/mkdep -s.o -p\$\(OBJDIR\)/ *.[ch] > build/djgpp/watt32.dep
   echo "neterr.c: build/djgpp/syserr.c"          >> build/djgpp/watt32.dep
 
   #
@@ -104,8 +113,8 @@ gen_djgpp ()
 gen_mingw32 ()
 {
   echo "Generating MinGW32 makefile, directory, errnos and dependencies"
-  ../util/linux/mkmake -o MinGW32.mak -d             build/MinGW32 makefile.all MINGW32 WIN32
-  ../util/linux/mkdep -s.o -p\$\(OBJDIR\)/ *.c *.h > build/MinGW32/watt32.dep
+  $util_dir/mkmake -o MinGW32.mak -d             build/MinGW32 makefile.all MINGW32 WIN32
+  $util_dir/mkdep -s.o -p\$\(OBJDIR\)/ *.c *.h > build/MinGW32/watt32.dep
   echo "neterr.c: build/MinGW32/syserr.c"         >> build/MinGW32/watt32.dep
 
   #
@@ -125,9 +134,9 @@ gen_mingw32 ()
 gen_mingw64 ()
 {
   echo "Generating MinGW64-w64 makefiles, directory, errnos and dependencies"
-  ../util/linux/mkmake -o MinGW64_32.mak -d          build/MinGW64/32bit makefile.all MINGW64 WIN32
-  ../util/linux/mkmake -o MinGW64_64.mak -d          build/MinGW64/64bit makefile.all MINGW64 WIN64
-  ../util/linux/mkdep -s.o -p\$\(OBJDIR\)/ *.c *.h > build/MinGW64/watt32.dep
+  $util_dir/mkmake -o MinGW64_32.mak -d          build/MinGW64/32bit makefile.all MINGW64 WIN32
+  $util_dir/mkmake -o MinGW64_64.mak -d          build/MinGW64/64bit makefile.all MINGW64 WIN64
+  $util_dir/mkdep -s.o -p\$\(OBJDIR\)/ *.c *.h > build/MinGW64/watt32.dep
   echo "neterr.c: build/MinGW64/syserr.c"         >> build/MinGW64/watt32.dep
 
   #
@@ -150,9 +159,9 @@ gen_mingw64 ()
 gen_cygwin ()
 {
   echo "Generating Cygwin makefiles, directories and dependencies"
-  ../util/linux/mkmake -o Cygwin_32.mak -d           build/CygWin/32bit makefile.all CYGWIN WIN32
-  ../util/linux/mkmake -o Cygwin_64.mak -d           build/CygWin/64bit makefile.all CYGWIN WIN64
-  ../util/linux/mkdep -s.o -p\$\(OBJDIR\)/ *.c *.h > build/CygWin/watt32.dep
+  $util_dir/mkmake -o Cygwin_32.mak -d           build/CygWin/32bit makefile.all CYGWIN WIN32
+  $util_dir/mkmake -o Cygwin_64.mak -d           build/CygWin/64bit makefile.all CYGWIN WIN64
+  $util_dir/mkdep -s.o -p\$\(OBJDIR\)/ *.c *.h > build/CygWin/watt32.dep
 
   echo "Run GNU make to make target(s):"
   echo "    'make -f Cygwin_32.mak'"
@@ -168,12 +177,12 @@ gen_cygwin ()
 gen_clang ()
 {
   echo "Generating clang-cl (Win32/Win64, release/debug) makefiles, directories, errnos and dependencies"
-  ../util/linux/mkmake -o clang-release_32.mak -d build/clang/32bit/release makefile.all CLANG WIN32 RELEASE
-  ../util/linux/mkmake -o clang-release_64.mak -d build/clang/64bit/release makefile.all CLANG WIN64 RELEASE
-  ../util/linux/mkmake -o clang-debug_32.mak   -d build/clang/32bit/debug   makefile.all CLANG WIN32 DEBUG
-  ../util/linux/mkmake -o clang-debug_64.mak   -d build/clang/64bit/debug   makefile.all CLANG WIN64 DEBUG
+  $util_dir/mkmake -o clang-release_32.mak -d build/clang/32bit/release makefile.all CLANG WIN32 RELEASE
+  $util_dir/mkmake -o clang-release_64.mak -d build/clang/64bit/release makefile.all CLANG WIN64 RELEASE
+  $util_dir/mkmake -o clang-debug_32.mak   -d build/clang/32bit/debug   makefile.all CLANG WIN32 DEBUG
+  $util_dir/mkmake -o clang-debug_64.mak   -d build/clang/64bit/debug   makefile.all CLANG WIN64 DEBUG
 
-  ../util/linux/mkdep -s.obj -p\$\(OBJDIR\)/ *.[ch] > build/clang/watt32.dep
+  $util_dir/mkdep -s.obj -p\$\(OBJDIR\)/ *.[ch] > build/clang/watt32.dep
   echo "neterr.c: build/clang/syserr.c"            >> build/clang/watt32.dep
 
   #
@@ -192,12 +201,12 @@ gen_clang ()
 gen_watcom ()
 {
   echo "Generating Watcom makefiles, directories, errnos and dependencies"
-  ../util/linux/mkmake -w -o watcom_s.mak -d build/watcom/small   makefile.all WATCOM SMALL
-  ../util/linux/mkmake -w -o watcom_l.mak -d build/watcom/large   makefile.all WATCOM LARGE
-  ../util/linux/mkmake -w -o watcom_3.mak -d build/watcom/small32 makefile.all WATCOM SMALL32
-  ../util/linux/mkmake -w -o watcom_f.mak -d build/watcom/flat    makefile.all WATCOM FLAT
-  ../util/linux/mkmake -w -o watcom_x.mak -d build/watcom/x32vm   makefile.all WATCOM FLAT X32VM
-  ../util/linux/mkmake -w -o watcom_w.mak -d build/watcom/win32   makefile.all WATCOM WIN32
+  $util_dir/mkmake -w -o watcom_s.mak -d build/watcom/small   makefile.all WATCOM SMALL
+  $util_dir/mkmake -w -o watcom_l.mak -d build/watcom/large   makefile.all WATCOM LARGE
+  $util_dir/mkmake -w -o watcom_3.mak -d build/watcom/small32 makefile.all WATCOM SMALL32
+  $util_dir/mkmake -w -o watcom_f.mak -d build/watcom/flat    makefile.all WATCOM FLAT
+  $util_dir/mkmake -w -o watcom_x.mak -d build/watcom/x32vm   makefile.all WATCOM FLAT X32VM
+  $util_dir/mkmake -w -o watcom_w.mak -d build/watcom/win32   makefile.all WATCOM WIN32
 
   #
   # This require dosemu be installed

--- a/src/configur.sh
+++ b/src/configur.sh
@@ -93,7 +93,9 @@ usage ()
 gen_djgpp ()
 {
   echo "Generating DJGPP makefile, directory and dependencies"
-  echo "BIN_PREFIX = $DJGPP_PREFIX-" > djgpp.mak
+  echo "BIN_PREFIX = $DJGPP_PREFIX-"                 >  djgpp.mak
+  echo "W32_BIN2C_ = $util_dir/bin2c"                >> djgpp.mak
+  echo "W32_NASM_ ?= nasm"                           >> djgpp.mak
   $util_dir/mkmake -d build/djgpp makefile.all DJGPP >> djgpp.mak
   $util_dir/mkdep -s.o -p\$\(OBJDIR\)/ *.[ch] > build/djgpp/watt32.dep
   echo "neterr.c: build/djgpp/syserr.c"          >> build/djgpp/watt32.dep

--- a/src/configur.sh
+++ b/src/configur.sh
@@ -93,10 +93,10 @@ usage ()
 gen_djgpp ()
 {
   echo "Generating DJGPP makefile, directory and dependencies"
-  echo "BIN_PREFIX = $DJGPP_PREFIX-"                 >  djgpp.mak
-  echo "W32_BIN2C_ = $util_dir/bin2c"                >> djgpp.mak
-  echo "W32_NASM_ ?= nasm"                           >> djgpp.mak
-  $util_dir/mkmake -d build/djgpp makefile.all DJGPP >> djgpp.mak
+  echo "BIN_PREFIX = $DJGPP_PREFIX-"                      >  djgpp.mak
+  echo "W32_BIN2C_ = $util_dir/bin2c"                     >> djgpp.mak
+  echo "W32_NASM_ ?= nasm"                                >> djgpp.mak
+  $util_dir/mkmake -d build/djgpp makefile.all DJGPP FLAT >> djgpp.mak
   $util_dir/mkdep -s.o -p\$\(OBJDIR\)/ *.[ch] > build/djgpp/watt32.dep
   echo "neterr.c: build/djgpp/syserr.c"          >> build/djgpp/watt32.dep
 

--- a/src/makefile.all
+++ b/src/makefile.all
@@ -251,32 +251,6 @@ PKT_STUB = pkt_stub.h
 #
 prefix = /dev/env/DJDIR/net/watt
 
-ifeq ($(OS),Windows_NT)
-  ifneq ($(DJ_PREFIX),)
-    #
-    # Windows hosted djgpp cross compiler. Get it from:
-    #   https://github.com/andrewwutw/build-djgpp/releases  - djgpp-mingw-gcc*.zip
-    #
-    # and install to e.g. 'c:/djgpp/contrib'.
-    # And then define an env-var:
-    #   DJ_PREFIX=c:/djgpp/contrib/win-cross/bin/i586-pc-msdosdjgpp-
-    #
-    # Thus the full path to 'gcc' becomes:
-    #   $(DJ_PREFIX)gcc.exe
-    #
-    # If not building on Windows, the '$(BIN_PREFIX)gcc' should simply become
-    # 'gcc' and GNU-make should find that on %PATH.
-    #
-    BIN_PREFIX = $(DJ_PREFIX)
-
-    ifeq ($(wildcard $(BIN_PREFIX)gcc.exe),)
-      $(error Failed to find 'i586-pc-msdosdjgpp-gcc.exe'.)
-    endif
-  endif
-else
-  BIN_PREFIX =
-endif
-
 CFLAGS = -O3 -g -I. -I../inc -DWATT32_BUILD -W -Wall -Wno-strict-aliasing \
          -march=i386 -mtune=i586
 

--- a/src/makefile.all
+++ b/src/makefile.all
@@ -254,15 +254,6 @@ prefix = /dev/env/DJDIR/net/watt
 CFLAGS = -O3 -g -I. -I../inc -DWATT32_BUILD -W -Wall -Wno-strict-aliasing \
          -march=i386 -mtune=i586
 
-ifeq ($(filter 2 3 4,$(word 3, $(shell true | $(CC) -E -dD -x c - | grep 'define\ *__GNUC__'))),)
-  #
-  # We have gcc >= 5.x and we must ensure that always traditional
-  # GNU extern inline semantics are used (aka -fgnu89-inline) even
-  # if ISO C99 semantics have been specified.
-  #
-  CFLAGS += -fgnu89-inline
-endif
-
 STAT_LIB = ../lib/libwatt.a
 OBJDIR   = build/djgpp
 OBJPATH  = $(OBJDIR)/
@@ -271,6 +262,15 @@ CC     = $(BIN_PREFIX)gcc
 AR     = $(BIN_PREFIX)ar rs
 AS     = $(BIN_PREFIX)as
 AFLAGS = # --gdwarf2
+
+ifeq ($(filter 2 3 4,$(word 3, $(shell true | $(CC) -E -dD -x c - | grep 'define\ *__GNUC__'))),)
+  #
+  # We have gcc >= 5.x and we must ensure that always traditional
+  # GNU extern inline semantics are used (aka -fgnu89-inline) even
+  # if ISO C99 semantics have been specified.
+  #
+  CFLAGS += -fgnu89-inline
+endif
 
 OBJS := $(subst .obj,.o,$(OBJS))
 

--- a/util/dj-errno.mak
+++ b/util/dj-errno.mak
@@ -15,11 +15,6 @@ default all:
 	@echo 'Usage: "make -f dj-errno.mak dj_err.exe"'
 	@echo '    or "make -f dj-errno.mak win32/dj_err.exe" (requires a MinGW gcc)'
 
-#
-# Assume plain DOS for now.
-#
-BIN_PREFIX =
-
 ifeq ($(OS),Windows_NT)
   ifneq ($(DJ_PREFIX),)
     #


### PR DESCRIPTION
Here are some patches that should make cross-compiling to djgpp a less confusing experience:

* It is now possible to use `configur.sh` from a Bash shell under mingw-w64/MSYS2.

* `BIN_PREFIX` is detected automatically and written to the makefile.  The compiler should just be in the user's `PATH`.  If someone does need to specify the full path, this can still be done by setting `DJGPP_PREFIX` before calling `configur.sh`

* `W32_NASM_` and `W32_BIN2C_` are written to the makefile. (why do these have underscores for djgpp, but not for other platforms?)

* `dj_errno.exe` can be cross-compiled by setting `BIN_PREFIX` before calling `make`.

* `mkmake` is called with `FLAT` so that `PKT_STUB` is defined for djgpp.
