### PR TITLE
replace 'cdecl' with 'W32_CDECL' [fixes #60]

### DIFF
--- a/bin/finger.c
+++ b/bin/finger.c
@@ -113,7 +113,7 @@ void usage (void)
   exit (3);
 }
 
-int cdecl main (int argc, char **argv)
+int W32_CDECL main (int argc, char **argv)
 {
   char  *user   = NULL;
   char  *server = "@localhost";

--- a/bin/host.c
+++ b/bin/host.c
@@ -529,7 +529,7 @@ DWORD new_resolve (const char *name)
 }
 
 
-int cdecl main (int argc, char **argv)
+int W32_CDECL main (int argc, char **argv)
 {
   char *name;
   DWORD host;

--- a/inc/sys/cdefs.h
+++ b/inc/sys/cdefs.h
@@ -139,20 +139,23 @@
 #endif
 
 #if defined(__CCDL__)    /* LadSoft compiler */
-  #define cdecl _cdecl
+  #define W32_CDECL _cdecl
 
-#elif !defined(cdecl) && (defined(__MINGW32__) || defined(__CYGWIN__))
-  #define cdecl __attribute__((__cdecl__))
+#elif defined(__MINGW32__) || defined(__CYGWIN__)
+  #if defined(cdecl)
+    #define W32_CDECL cdecl
+  #else
+    #define W32_CDECL __attribute__((__cdecl__))
+  #endif
 #endif
 
 #if defined(_MSC_VER) || defined(__POCC__)
-  #undef cdecl
   #if (_MSC_VER <= 600) && !defined(__POCC__)
-    #define cdecl _cdecl
+    #define W32_CDECL _cdecl
     #undef  __STDC__
     #define __STDC__ 1
   #else
-    #define cdecl __cdecl
+    #define W32_CDECL __cdecl
   #endif
   #define NO_ANSI_KEYWORDS
 
@@ -161,8 +164,8 @@
   /* e.g. int NO_UNDERSCORE foo (void); */
 #endif
 
-#ifndef cdecl
-#define cdecl
+#ifndef W32_CDECL
+#define W32_CDECL
 #endif
 
 /*
@@ -193,19 +196,15 @@
    * Ref. the use of 'WINAPIV' in the Windows SDKs.
    *
    * But Watcom's register call doesn't need this. (wcc386 -ecf)
+   *
+   * See <sys/w32api.h> for the rationale behind 'W32_CALL'. It's
+   * currently forced to 'cdecl' on Windows. Thus 'MS_CDECL' should be
+   * important for MSVC users on Windows only. But I'm not sure....
    */
   #undef  MS_CDECL
-  #define MS_CDECL   cdecl
-
-  /* See <sys/w32api.h> for the rationale behind 'W32_CALL'. It's
-   * currently forced to 'cdecl' on Windows. Thus 'W32_CDECL' and 'MS_CDECL'
-   * should be important for MSVC users on Windows only. But I'm not
-   * sure....
-   */
-  #define W32_CDECL  cdecl
+  #define MS_CDECL   W32_CDECL
 #else
   #define MS_CDECL
-  #define W32_CDECL
 #endif
 
 

--- a/inc/sys/swap.h
+++ b/inc/sys/swap.h
@@ -38,8 +38,8 @@ __BEGIN_DECLS
   W32_FUNC unsigned long  W32_CALL htonl (unsigned long);
 #endif
 
-W32_FUNC unsigned long  cdecl _w32_intel   (unsigned long x);
-W32_FUNC unsigned short cdecl _w32_intel16 (unsigned short x);
+W32_FUNC unsigned long  W32_CDECL _w32_intel   (unsigned long x);
+W32_FUNC unsigned short W32_CDECL _w32_intel16 (unsigned short x);
 
 #undef  ntohs
 #undef  htons
@@ -216,8 +216,8 @@ W32_FUNC unsigned short cdecl _w32_intel16 (unsigned short x);
 
   #define WATT32_NO_INLINE_INTEL
 
-  W32_FUNC unsigned long  cdecl intel   (unsigned long x);
-  W32_FUNC unsigned short cdecl intel16 (unsigned short x);
+  W32_FUNC unsigned long  W32_CDECL intel   (unsigned long x);
+  W32_FUNC unsigned short W32_CDECL intel16 (unsigned short x);
 
 #elif (defined(__BORLANDC__) && defined(__FLAT__)) ||  /* bcc32 (flat/win32) */ \
       (defined(__DMC__) && (__INTSIZE==4))             /* dmc -mx */
@@ -302,8 +302,8 @@ W32_FUNC unsigned short cdecl _w32_intel16 (unsigned short x);
 
   #define WATT32_NO_INLINE_INTEL
 
-  W32_FUNC unsigned long  cdecl intel   (unsigned long x);
-  W32_FUNC unsigned short cdecl intel16 (unsigned short x);
+  W32_FUNC unsigned long  W32_CDECL intel   (unsigned long x);
+  W32_FUNC unsigned short W32_CDECL intel16 (unsigned short x);
 #endif
 
 __END_DECLS

--- a/inc/sys/syslog.h
+++ b/inc/sys/syslog.h
@@ -150,7 +150,7 @@ W32_FUNC void  W32_CALL  closelog   (void);
 W32_FUNC void  W32_CALL  openlog    (const char *, int, int);
 W32_FUNC int   W32_CALL  setlogmask (int);
 W32_FUNC char *W32_CALL  setlogtag  (char *new_tag); /* non-standard */
-W32_FUNC void  W32_CDECL syslog     (int, const char *, ...);
+W32_FUNC void  MS_CDECL  syslog     (int, const char *, ...);
 W32_FUNC void  W32_CALL  vsyslog    (int, const char *, va_list);
 
 __END_DECLS

--- a/src/misc.c
+++ b/src/misc.c
@@ -170,7 +170,7 @@ STATIC void test_stk_check (void)
  * Convert 32-bit big-endian (network order) to intel (host order) format.
  * Or vice-versa. These are cdecl incase we patch them.
  */
-unsigned long cdecl _w32_intel (unsigned long val)
+unsigned long W32_CDECL _w32_intel (unsigned long val)
 {
   return ((val & 0x000000FFU) << 24) |
          ((val & 0x0000FF00U) <<  8) |
@@ -182,7 +182,7 @@ unsigned long cdecl _w32_intel (unsigned long val)
  * Convert 16-bit big-endian (network order) to intel (host order) format.
  * Or vice-versa
  */
-unsigned short cdecl _w32_intel16 (unsigned short val)
+unsigned short W32_CDECL _w32_intel16 (unsigned short val)
 {
   return ((val & 0x00FF) << 8) | ((val & 0xFF00) >> 8);
 }

--- a/src/syslog.c
+++ b/src/syslog.c
@@ -112,7 +112,7 @@ CODE facilitynames[] = {
  * syslog, vsyslog --
  *   print message on log file; output is intended for syslogd(8).
  */
-void W32_CDECL syslog (int pri, const char *fmt, ...)
+void MS_CDECL syslog (int pri, const char *fmt, ...)
 {
   va_list args;
   va_start (args, fmt);

--- a/src/winadinf.c
+++ b/src/winadinf.c
@@ -338,8 +338,8 @@ struct one_addr {
 typedef char address_buf [MAX_IP6_SZ+1];
 
 W32_DATA int                  _w32_errno;
-W32_FUNC unsigned long  cdecl _w32_intel (unsigned long x);
-W32_FUNC unsigned short cdecl _w32_intel16 (unsigned short x);
+W32_FUNC unsigned long  W32_CDECL _w32_intel (unsigned long x);
+W32_FUNC unsigned short W32_CDECL _w32_intel16 (unsigned short x);
 W32_FUNC const char *W32_CALL _w32_inet_ntop (int af, const void *src,
                                               char *dst, size_t size);
 /*


### PR DESCRIPTION
Observations:

* `MS_CDECL` and `W32_CDECL` are *always* identical.
* `W32_CDECL` is only used for one single function (`syslog()`).

Therefore, we can use `MS_CDECL` for this function too and repurpose `W32_CDECL` for what is currently `cdecl`.

`cdecl` is also used a lot in `src/`, but `src/target.h` already defines `cdecl` too.  So we don't need to change anything there.
