### PR TITLE
Add missing includes in <netinet/tcp.h> [fixes #59]

### DIFF
--- a/inc/netinet/tcp.h
+++ b/inc/netinet/tcp.h
@@ -38,6 +38,9 @@
 #ifndef __NETINET_TCP_H
 #define __NETINET_TCP_H
 
+#include <sys/cdefs.h>
+#include <sys/wtypes.h>
+
 typedef u_long  tcp_seq;
 typedef u_long  tcp_cc;                 /* connection count per rfc1644 */
 


### PR DESCRIPTION
I checked all headers to see if they would compile on their own.  This is the only one that was missing some includes.