### PR TITLE
Fix detecting DJGPP_PREFIX in configur.sh

### DIFF
--- a/src/configur.sh
+++ b/src/configur.sh
@@ -31,9 +31,10 @@ esac
 # target triplet for cross-djgpp toolchain:
 #
 if [ -z "$DJGPP_PREFIX" ]; then
-  for i in i{3..7}86-pc-msdosdjgpp; do
-    if which $i-gcc 2>&1 > /dev/null; then
-      DJGPP_PREFIX=$i
+  for i in $(seq 3 7); do
+    prefix=i${i}86-pc-msdosdjgpp
+    if which $prefix-gcc > /dev/null 2>&1; then
+      DJGPP_PREFIX=$prefix
       break
     fi
   done


### PR DESCRIPTION
The `{3..7}` syntax appears to be Bash-specific and does not work if
`/bin/sh` is not actually Bash.  Using `seq` should be more portable.