### PR TITLE
Handle recursive `include_next`

### DIFF
--- a/inc/sys/cdefs.h
+++ b/inc/sys/cdefs.h
@@ -393,4 +393,13 @@
   #endif
 #endif
 
-#endif
+#else /* __SYS_CDEFS_H */
+
+  /*
+   * Handle recursive include_next.
+   */
+  #if defined(__DJGPP__) || defined(__CYGWIN__) || defined(__MINGW64__)
+    #include_next <sys/cdefs.h>
+  #endif
+
+#endif /* __SYS_CDEFS_H */

--- a/inc/sys/ioctl.h
+++ b/inc/sys/ioctl.h
@@ -129,15 +129,11 @@
 #define SIOCGLOWAT  _IOR('s',  3, int)    /* get low watermark */
 #define SIOCATMARK  _IOR('s',  7, int)    /* at oob mark? */
 
+#endif /* !__SYS_IOCTL_H */
+
 /* Since this file shadows the normal djgpp <sys/ioctl.h>, we include
  * that last.
  */
 #if defined(__DJGPP__)
-  #if 0
-    #include "/dev/env/DJDIR/include/sys/ioctl.h"  /* ioctl() */
-  #else
-    #include_next <sys/ioctl.h>                    /* ioctl() */
-  #endif
+  #include_next <sys/ioctl.h>                    /* ioctl() */
 #endif
-
-#endif /* !__SYS_IOCTL_H */


### PR DESCRIPTION
When the include path contains the Watt-32 header directory multiple times, `#include_next` breaks, since two headers have it located inside the include guard.

This scenario can happen when a project builds a local copy of Watt-32, but the user has their own copy in the global include path already.  In this case we want to use the local version of the header, so the recursive `#include_next` must be placed at the end of the header file.