### PR TITLE
Include djgpp's <sys/uio.h>

### DIFF
--- a/inc/sys/uio.h
+++ b/inc/sys/uio.h
@@ -9,3 +9,7 @@
  */
 
 #endif
+
+#if defined(__DJGPP__)
+  #include_next <sys/uio.h>
+#endif

--- a/inc/sys/wtypes.h
+++ b/inc/sys/wtypes.h
@@ -61,6 +61,11 @@
   #include <sys/version.h>      /* for DJGPP_MINOR */
 #endif
 
+#if defined(__DJGPP__)
+  #include <sys/uio.h>          /* for struct iovec */
+  #define IOVEC_DEFINED
+#endif
+
 #if defined(__MINGW32__) || (defined(__DJGPP__) && DJGPP_MINOR >= 4) || \
     (defined(__WATCOMC__) && __WATCOMC__ >= 1230) ||  /* OW 1.3+ */     \
     defined(__POCC__)    ||                           /* PellesC */     \

--- a/inc/sys/wtypes.h
+++ b/inc/sys/wtypes.h
@@ -51,6 +51,9 @@
 #include <sys/w32api.h>
 #endif
 
+#define __need_size_t
+#include <stddef.h>
+
 #if defined(__DJGPP__) || defined(__DMC__) || \
     defined(__MINGW32__) || defined(__CYGWIN__) || defined(__POCC__)
   #include <sys/types.h>

--- a/inc/sys/wtypes.h
+++ b/inc/sys/wtypes.h
@@ -219,8 +219,8 @@
 #if !defined(IOVEC_DEFINED)
   #define IOVEC_DEFINED
   struct iovec {
-         void *iov_base;
-         int   iov_len;
+         void   *iov_base;
+         size_t  iov_len;
        };
 #endif
 

--- a/src/receive.c
+++ b/src/receive.c
@@ -242,6 +242,14 @@ int W32_CALL recvmsg (int s, struct msghdr *msg, int flags)
     }
 #endif
 
+    if (iov[i].iov_len > (unsigned)INT_MAX)
+    {
+      SOCK_DEBUGF ((", EOVERFLOW (iovec[%d]: len %lu > INT_MAX)",
+                    i, (unsigned long)iov[i].iov_len));
+      SOCK_ERRNO (EOVERFLOW);
+      return (-1);
+    }
+
     len = receive (NULL, s, iov[i].iov_base, iov[i].iov_len,
                    msg->msg_flags, (struct sockaddr*)msg->msg_name,
                    (size_t*)&msg->msg_namelen);
@@ -279,6 +287,14 @@ int W32_CALL readv_s (int s, const struct iovec *vector, size_t count)
       return (-1);
     }
 #endif
+
+    if (vector[i].iov_len > (unsigned)INT_MAX)
+    {
+      SOCK_DEBUGF ((", EOVERFLOW (iovec[%d]: len %lu > INT_MAX)",
+                   (int)i, (unsigned long)vector[i].iov_len));
+      SOCK_ERRNO (EOVERFLOW);
+      return (-1);
+    }
 
     len = receive (NULL, s, vector[i].iov_base, vector[i].iov_len,
                    0, NULL, NULL);

--- a/src/receive.c
+++ b/src/receive.c
@@ -251,7 +251,7 @@ int W32_CALL recvmsg (int s, struct msghdr *msg, int flags)
       break;
     }
     bytes += len;
-    if (len != iov[i].iov_len)  /* nothing more to read */
+    if ((unsigned)len != iov[i].iov_len)  /* nothing more to read */
        break;
   }
   SOCK_DEBUGF ((", total %d", bytes));
@@ -288,7 +288,7 @@ int W32_CALL readv_s (int s, const struct iovec *vector, size_t count)
       break;
     }
     bytes += len;
-    if (len != vector[i].iov_len)  /* nothing more to read */
+    if ((unsigned)len != vector[i].iov_len)  /* nothing more to read */
        break;
   }
   SOCK_DEBUGF ((", total %d", bytes));

--- a/src/receive.c
+++ b/src/receive.c
@@ -234,8 +234,9 @@ int W32_CALL recvmsg (int s, struct msghdr *msg, int flags)
 #if (DOSX)
     if (!valid_addr(iov[i].iov_base, iov[i].iov_len))
     {
-      SOCK_DEBUGF ((", EFAULT (iovec[%d] = %p/%d)",
-                   (int)i, iov[i].iov_base, iov[i].iov_len));
+      SOCK_DEBUGF ((", EFAULT (iovec[%d] = %p/%lu)",
+                   (int)i, iov[i].iov_base,
+                   (unsigned long)iov[i].iov_len));
       SOCK_ERRNO (EFAULT);
       return (-1);
     }
@@ -271,8 +272,9 @@ int W32_CALL readv_s (int s, const struct iovec *vector, size_t count)
 #if (DOSX)
     if (!valid_addr(vector[i].iov_base, vector[i].iov_len))
     {
-      SOCK_DEBUGF ((", EFAULT (iovec[%d] = %p/%d)",
-                   (int)i, vector[i].iov_base, vector[i].iov_len));
+      SOCK_DEBUGF ((", EFAULT (iovec[%d] = %p/%lu)",
+                   (int)i, vector[i].iov_base,
+                   (unsigned long)vector[i].iov_len));
       SOCK_ERRNO (EFAULT);
       return (-1);
     }

--- a/src/transmit.c
+++ b/src/transmit.c
@@ -84,6 +84,14 @@ int W32_CALL writev_s (int s, const struct iovec *vector, size_t count)
     }
 #endif
 
+    if (vector[i].iov_len > (unsigned)INT_MAX)
+    {
+      SOCK_DEBUGF ((", EOVERFLOW (iovec[%d]: len %lu > INT_MAX)",
+                    i, (unsigned long)vector[i].iov_len));
+      SOCK_ERRNO (EOVERFLOW);
+      return (-1);
+    }
+
     len = transmit (NULL, s, vector[i].iov_base, vector[i].iov_len,
                     0, NULL, 0, FALSE);
     if (len < 0)
@@ -129,6 +137,14 @@ int W32_CALL sendmsg (int s, const struct msghdr *msg, int flags)
       return (-1);
     }
 #endif
+
+    if (iov[i].iov_len > (unsigned)INT_MAX)
+    {
+      SOCK_DEBUGF ((", EOVERFLOW (iovec[%d]: len %lu > INT_MAX)",
+                    i, (unsigned long)iov[i].iov_len));
+      SOCK_ERRNO (EOVERFLOW);
+      return (-1);
+    }
 
     len = transmit (NULL, s, iov[i].iov_base, iov[i].iov_len,
                     flags, (struct sockaddr*)msg->msg_name,

--- a/src/transmit.c
+++ b/src/transmit.c
@@ -76,8 +76,9 @@ int W32_CALL writev_s (int s, const struct iovec *vector, size_t count)
 #if (DOSX)
     if (!valid_addr(vector[i].iov_base, vector[i].iov_len))
     {
-      SOCK_DEBUGF ((", EFAULT (iovec[%d] = %p, len %d)",
-                    i, vector[i].iov_base, vector[i].iov_len));
+      SOCK_DEBUGF ((", EFAULT (iovec[%d] = %p, len %lu)",
+                    i, vector[i].iov_base,
+                    (unsigned long)vector[i].iov_len));
       SOCK_ERRNO (EFAULT);
       return (-1);
     }
@@ -121,8 +122,9 @@ int W32_CALL sendmsg (int s, const struct msghdr *msg, int flags)
 #if (DOSX)
     if (!valid_addr(iov[i].iov_base, iov[i].iov_len))
     {
-      SOCK_DEBUGF ((", EFAULT (iovec[%d] = %p/%d)",
-                   (int)i, iov[i].iov_base, iov[i].iov_len));
+      SOCK_DEBUGF ((", EFAULT (iovec[%d] = %p/%lu)",
+                   (int)i, iov[i].iov_base,
+                   (unsigned long)iov[i].iov_len));
       SOCK_ERRNO (EFAULT);
       return (-1);
     }


### PR DESCRIPTION
This exposes libc's `readv()`/`writev()` again.  `iov_len` must be made `size_t` to be compatible.
