### PR TITLE
Don't set EISCONN at first connect

### DIFF
--- a/src/select.c
+++ b/src/select.c
@@ -548,7 +548,7 @@ static int read_select (int s, Socket *socket)
     if ((socket->so_state & SS_NBIO) &&
         sk->tcp.state == tcp_StateESTAB &&
         socket->so_error == EALREADY)
-       socket->so_error = EISCONN;
+       socket->so_error = 0;
 
     if (sock_signalled(socket,READ_STATE_MASK) || /* signalled for read_s() */
         sk->tcp.state >= tcp_StateLASTACK      || /* got FIN from peer */
@@ -604,7 +604,7 @@ static int write_select (int s, Socket *socket)
     if (sk->tcp.state == tcp_StateESTAB)
     {
       if ((socket->so_state & SS_NBIO) && socket->so_error == EALREADY)
-         socket->so_error = EISCONN;
+         socket->so_error = 0;
 
       if (sock_tbleft(sk) > socket->send_lowat)  /* Tx room above low-limit */
          return (1);

--- a/src/select.c
+++ b/src/select.c
@@ -545,9 +545,8 @@ static int read_select (int s, Socket *socket)
   {
     sock_type *sk = (sock_type*) socket->tcp_sock;
 
-    if ((socket->so_state & SS_NBIO) &&
-        sk->tcp.state == tcp_StateESTAB &&
-        socket->so_error == EALREADY)
+    if (socket->so_error == EALREADY &&           /* Non-blocking connect() */
+        sk->tcp.state == tcp_StateESTAB)
        socket->so_error = 0;
 
     if (sock_signalled(socket,READ_STATE_MASK) || /* signalled for read_s() */
@@ -603,7 +602,7 @@ static int write_select (int s, Socket *socket)
 
     if (sk->tcp.state == tcp_StateESTAB)
     {
-      if ((socket->so_state & SS_NBIO) && socket->so_error == EALREADY)
+      if (socket->so_error == EALREADY)          /* Non-blocking connect() */
          socket->so_error = 0;
 
       if (sock_tbleft(sk) > socket->send_lowat)  /* Tx room above low-limit */


### PR DESCRIPTION
Linux manpage for `connect()` states that `SO_ERROR` will be 0 when a
connection is established on a non-blocking socket.  See description below
`EINPROGRESS`:

https://man7.org/linux/man-pages/man2/connect.2.html

> After select(2) indicates writability, use getsockopt(2) to read the SO_ERROR
> option at level SOL_SOCKET to determine whether connect() completed
> successfully **(SO_ERROR is zero)**

I think Watt32 should do the same.  It makes sense: establishing a connection
is not an error.

Also, I think a small optimization can be made here.  `EALREADY` can only be
set on a non-blocking socket, so testing for `SS_NBIO` is not necessary.
(please double-check if that is correct, otherwise drop the second commit)
