### PR TITLE
Yield while waiting for `connect()` to finish

### DIFF
--- a/src/receive.c
+++ b/src/receive.c
@@ -120,6 +120,10 @@ static int receive (const char *func, int s, void *buf, int len, int flags,
         SOCK_ERRNO (EAGAIN);
         return (-1);
       }
+
+      if (socket->tcp_sock->usr_yield)
+         (*socket->tcp_sock->usr_yield) ();
+      else WATT_YIELD ();
     }
   }
 

--- a/src/transmit.c
+++ b/src/transmit.c
@@ -282,6 +282,10 @@ static int transmit (const char *func, int s, const void *buf, unsigned len,
           SOCK_ERRNO (EAGAIN);
           return (-1);
         }
+
+        if (socket->tcp_sock->usr_yield)
+           (*socket->tcp_sock->usr_yield) ();
+        else WATT_YIELD ();
       }
     }
 


### PR DESCRIPTION
Forgot something in #80.  We should call `usr_yield` when in a tight loop.
