### PR TITLE
`connect()`: Allow non-TCP sockets to rebind `remote_addr`

### DIFF
--- a/src/connect.c
+++ b/src/connect.c
@@ -148,9 +148,6 @@ int W32_CALL connect (int s, const struct sockaddr *servaddr, socklen_t addrlen)
     }
 #endif
 
-    free (socket->remote_addr);
-    socket->remote_addr = NULL;
-
     /* Clear any effect of previous ICMP errors etc.
      */
     socket->so_state &= ~(SS_CONN_REFUSED | SS_CANTSENDMORE | SS_CANTRCVMORE);
@@ -162,13 +159,15 @@ int W32_CALL connect (int s, const struct sockaddr *servaddr, socklen_t addrlen)
       rdata = socket->udp_sock->rx_data;  /* preserve current data */
     }
   }
-
-  socket->remote_addr = (struct sockaddr_in*) SOCK_CALLOC (sa_len);
-  if (!socket->remote_addr)
+  else
   {
-    SOCK_DEBUGF ((", ENOMEM (rem)"));
-    SOCK_ERRNO (ENOMEM);
-    return (-1);
+    socket->remote_addr = SOCK_CALLOC (sa_len);
+    if (!socket->remote_addr)
+    {
+      SOCK_DEBUGF ((", ENOMEM (rem)"));
+      SOCK_ERRNO (ENOMEM);
+      return (-1);
+    }
   }
 
 #if defined(USE_IPV6)

--- a/src/pctcp.h
+++ b/src/pctcp.h
@@ -126,6 +126,9 @@ extern char hostname [MAX_HOSTLEN+1];
 extern _tcp_Socket *_tcp_allsocs;
 extern _udp_Socket *_udp_allsocs;
 
+extern int _udp_listen (_udp_Socket *s, WORD lport, DWORD ip, WORD port);
+extern int _udp_open   (_udp_Socket *s, WORD lport, DWORD ip, WORD port);
+
 extern void _udp_cancel (const in_Header *ip, int icmp_type, int icmp_code,
                          const char *msg, const void *arg);
 

--- a/src/socket.c
+++ b/src/socket.c
@@ -1946,10 +1946,12 @@ int _UDP_open (Socket *socket, struct in_addr host, WORD loc_port, WORD rem_port
   loc_port = ntohs (loc_port);
   rem_port = ntohs (rem_port);
 
-  if (!udp_open (socket->udp_sock, loc_port, ip, rem_port, NULL))
+  if (!_udp_open (socket->udp_sock, loc_port, ip, rem_port))
      return (0);
 
-  _sock_set_rcv_buf ((sock_type*)socket->udp_sock, DEFAULT_UDP_SIZE);
+  if (!socket->udp_sock->rx_data)
+     _sock_set_rcv_buf ((sock_type*)socket->udp_sock, DEFAULT_UDP_SIZE);
+
   socket->udp_sock->icmp_callb = (icmp_upcall) icmp_callback;
   return (1);
 }
@@ -2155,7 +2157,10 @@ int _TCP6_listen (Socket *socket, const void *host, WORD loc_port)
 int _UDP6_open (Socket *socket, const void *host, WORD loc_port, WORD rem_port)
 {
   /** \todo Support UDP connect() for AF_INET6 */
-  _sock_set_rcv_buf ((sock_type*)socket->udp_sock, DEFAULT_UDP_SIZE);
+
+  if (!socket->udp_sock->rx_data)
+     _sock_set_rcv_buf ((sock_type*)socket->udp_sock, DEFAULT_UDP_SIZE);
+
   socket->udp_sock->icmp_callb = (icmp_upcall) icmp_callback;
   ARGSUSED (host);
   ARGSUSED (loc_port);


### PR DESCRIPTION
Noticed this while working on #80.  For non-`SOCK_STREAM` sockets, it should be possible to rebind the destination address by calling `connect()` again.

https://man7.org/linux/man-pages/man2/connect.2.html

> Some protocol sockets (e.g., UNIX domain stream sockets) may
> successfully connect() only once.
> 
> Some protocol sockets (e.g., datagram sockets in the UNIX and
> Internet domains) may use connect() multiple times to change
> their association.

Not tested, but it should work since I just copied the code from `transmit.c`.
