### PR TITLE
Made 'select_s' compile correctly when build defines 'W32_NO_8087'

### DIFF
--- a/src/select.c
+++ b/src/select.c
@@ -324,17 +324,26 @@ int W32_CALL select_s (int nfds, fd_set *readfds, fd_set *writefds,
        */
       if (timeout)
       {
+#if defined(W32_NO_8087)
+        *timeout = timeval_diff2(&now, &expiry);
+#else
         double remaining = timeval_diff (&now, &expiry);
 
         timeout->tv_sec  = (long)(remaining / 1E6);
         timeout->tv_usec = (long)remaining % 1000000UL;
+#endif
       }
       goto select_ok;
     }
 
     if (expired)
     {
+#if defined(W32_NO_8087) && defined(USE_DEBUG)
+      struct timeval diff = timeval_diff2(&now, &starttime);
+      SOCK_DEBUGF ((", timeout!: %d.%03u", diff.tv_sec, diff.tv_usec));
+#else
       SOCK_DEBUGF ((", timeout!: %.6fs", timeval_diff(&now, &starttime)/1E6));
+#endif
 
       if (readfds)
          for (s = 0; s < num_fd; s++)


### PR DESCRIPTION
Fixed Watcom linking error when program makes use of `select_s` but `W32_NO_8087` has been defined
```
Error! E2028: _w32_timeval_diff_ is an undefined reference
```
To replicate the problem: checkout adeb8e011d4499c2c4d876b1078e339add992461 and build `WATTCPWL.LIB` with `#define USE_BSD_API` then link the following test program against it
```c
/* Compile with `OWCC -I INC LIB\WATTCPWL.LIB TEST.C` */

#include <stdio.h>
#include <stdlib.h>
#include <sys/select.h>

void foo(void) {
	/* Isn't run, just testing select() can be linked */
	select(0, NULL, NULL, NULL, NULL);
}

int main (int argc, char *argv[]) {
	puts("I compiled!");
	return 0;
}
```