### PR TITLE
Avoid running daemon on every loop in `select_s()`/`poll()`

### DIFF
--- a/src/select.c
+++ b/src/select.c
@@ -478,7 +478,7 @@ poll_ok:
 int _fsext_ready (int fd)
 {
   Socket *socket;
-  int revents, ret = 0;
+  int     revents, ret = 0;
 
   tcp_tick (NULL);
 
@@ -495,7 +495,7 @@ int _fsext_ready (int fd)
   if (revents & POLLPRI)
      ret |= __FSEXT_ready_error;
 
-   return ret;
+   return (ret);
 }
 #endif /* __DJGPP__ && USE_FSEXT */
 

--- a/src/select.c
+++ b/src/select.c
@@ -749,14 +749,14 @@ static int select_one (int fd, Socket *socket, int events)
   if (socket)
      connecting = still_connecting (socket);
 
-  if (events & POLLIN)                  /* readable or error */
+  if (events & POLLIN)                  /* check if readable or error */
   {
     if (read_select (fd, socket) ||
         (socket && sock_signalled (socket, READ_STATE_MASK)))
        revents |= POLLIN;
   }
 
-  if ((events & POLLOUT) &&             /* writable or error */
+  if ((events & POLLOUT) &&             /* check if writable or error */
       !connecting)                      /* skip if still connecting */
   {
     if (write_select (fd, socket) ||
@@ -764,7 +764,7 @@ static int select_one (int fd, Socket *socket, int events)
        revents |= POLLOUT;
   }
 
-  if (events & POLLPRI)                 /* OOB data */
+  if (events & POLLPRI)                 /* check for OOB data */
   {
     if (exc_select (fd, socket))
        revents |= POLLPRI;
@@ -792,13 +792,13 @@ static int poll_one (int fd, Socket *socket, int events)
        revents |= POLLERR;
   }
 
-  if (events & POLLIN)                          /* readable */
+  if (events & POLLIN)                          /* check if readable */
   {
     if (read_select (fd, socket))
        revents |= POLLIN;
   }
 
-  if ((events & POLLOUT) &&                     /* writable */
+  if ((events & POLLOUT) &&                     /* check if writable */
       !(revents & POLLHUP) &&                   /* but skip if closed */
       !connecting)                              /* or still connecting */
   {
@@ -806,7 +806,7 @@ static int poll_one (int fd, Socket *socket, int events)
        revents |= POLLOUT;
   }
 
-  if (events & POLLPRI)                         /* OOB data */
+  if (events & POLLPRI)                         /* check for OOB data */
   {
     if (exc_select (fd, socket))
        revents |= POLLPRI;

--- a/src/select.c
+++ b/src/select.c
@@ -417,10 +417,6 @@ int W32_CALL poll (struct pollfd *p, int num, int timeout_ms)
    */
   while (1)
   {
-    /* Not safe to run sock_daemon() (or other "tasks") now
-     */
-    _sock_crit_start();
-
     tcp_tick (NULL);
 
     for (i = 0; i < num; ++i)
@@ -446,10 +442,6 @@ int W32_CALL poll (struct pollfd *p, int num, int timeout_ms)
       p[i].revents = POLLNVAL;
       ++ret;
     }
-
-    /* Safe to run other "tasks" now.
-     */
-    _sock_crit_stop();
 
     /* Poll for caught signals (SIGINT/SIGALRM)
      */


### PR DESCRIPTION
Small addition to #87.  Possible alternative: Use a flag in `_sock_crit_stop()` to only run daemon if it was missed previously.

Also some minor improvements to comments and code style.
