### PR TITLE
Don't set `so_error` in `shutdown()`

### DIFF
--- a/src/shutdown.c
+++ b/src/shutdown.c
@@ -57,7 +57,6 @@ int W32_CALL shutdown (int s, int how)
   switch (how)
   {
     case SHUT_RD:
-         socket->so_error    = ESHUTDOWN;
          socket->so_state   |=  SS_CANTRCVMORE;
       /* socket->so_options &= ~SO_ACCEPTCONN; */
 
@@ -67,7 +66,6 @@ int W32_CALL shutdown (int s, int how)
          return (0);
 
     case SHUT_WR:
-         socket->so_error    = ESHUTDOWN;
          socket->so_state   |=  SS_CANTSENDMORE;
          socket->so_state   &= ~SS_ISLISTENING;
       /* socket->so_options &= ~SO_ACCEPTCONN; */
@@ -79,7 +77,6 @@ int W32_CALL shutdown (int s, int how)
          return (0);
 
     case SHUT_RDWR:
-         socket->so_error    = ESHUTDOWN;
          socket->so_state   |= (SS_CANTRCVMORE | SS_CANTSENDMORE);
          socket->so_state   &= ~SS_ISLISTENING;
       /* socket->so_options &= ~SO_ACCEPTCONN; */


### PR DESCRIPTION
Ran into this recently when I made a websocket server using Boost.  After any `shutdown()` is called, the next operation always fails with `ESHUTDOWN`.

What happens is: when the WS client sends a "close" header, the server (Boost code) calls `shutdown(SHUT_WR)` to send FIN, then continues to `recv()` the rest of the message.  But it gets confused due to the error, so WS sessions never terminate cleanly.

Simple solution is to not set `so_error`.  Note that this does remove all current uses of `ESHUTDOWN`.

Would also be nice if `shutdown()` could actually send the FIN.  I think most code from `close_s()` can be moved here.
