### PR TITLE
More improvements in select.c

### DIFF
--- a/src/select.c
+++ b/src/select.c
@@ -47,8 +47,6 @@
 #pragma stack_size_warn (16000)    /* ~3*MAX_SOCKETS */
 #endif
 
-#define ALWAYS_YIELD  0
-
 #ifndef STDIN_FILENO
 #define STDIN_FILENO  0
 #endif
@@ -60,13 +58,6 @@
 #ifndef STDERR_FILENO
 #define STDERR_FILENO 2
 #endif
-
-
-/**
- * The smallest time for \b not yielding or calling tcp_tick().
- * \todo Should be configurable.
- */
-static struct timeval sel_min_block = { 0, 500000 }; /* 0.5 sec */
 
 /*
  * Select sockets for read, write or exceptions
@@ -343,15 +334,7 @@ int W32_CALL select_s (int nfds, fd_set *readfds, fd_set *writefds,
       break;
     }
 
-    /* WATT_YIELD() sometimes hangs for approx 250msec under Win-XP.
-     * Don't yield for "small" timeouts.
-     */
-#if (!ALWAYS_YIELD)
-    if (!timeout || timercmp(timeout,&sel_min_block,>))
-#endif
-    {
-      WATT_YIELD();
-    }
+    WATT_YIELD();
   }
 
   _sock_sig_restore();

--- a/src/select.c
+++ b/src/select.c
@@ -185,23 +185,13 @@ int W32_CALL select_s (int nfds, fd_set *readfds, fd_set *writefds,
   /* Not safe to run sock_daemon() (or other "tasks") now
    */
   _sock_crit_start();
-
-  /* If application catches same signals we do, we must exit
-   * gracefully from the do-while and for loops below.
-   */
-  if (_sock_sig_setup() < 0)
-     goto select_intr;
+  _sock_sig_setup();
 
   /*
    * Loop until specified timeout expires or event(s) satisfied.
    */
   for (loop_1st = TRUE, loops = 1;; loop_1st = FALSE, loops++)
   {
-    /* Poll for caught signals (SIGINT/SIGALRM)
-     */
-    if (_sock_sig_pending())
-       goto select_intr;
-
     tcp_tick (NULL);
 
     for (s = 0; s < num_fd; s++)
@@ -329,7 +319,7 @@ int W32_CALL select_s (int nfds, fd_set *readfds, fd_set *writefds,
         timeout->tv_usec = (long)remaining % 1000000UL;
 #endif
       }
-      goto select_ok;
+      break;
     }
 
     if (expired)
@@ -354,16 +344,20 @@ int W32_CALL select_s (int nfds, fd_set *readfds, fd_set *writefds,
              FD_CLR (s, exceptfds);
 
       ret_count = 0;   /* should already be 0 */
-      goto select_ok;
+      break;
+    }
+
+    /* Poll for caught signals (SIGINT/SIGALRM)
+     */
+    if (_sock_sig_pending())
+    {
+      SOCK_DEBUGF ((", EINTR"));
+      SOCK_ERRNO (EINTR);
+      ret_count = -1;
+      break;
     }
   }
 
-select_intr:
-  SOCK_DEBUGF ((", EINTR"));
-  SOCK_ERRNO (EINTR);
-  ret_count = -1;
-
-select_ok:
   _sock_sig_restore();
   _sock_crit_stop();
 
@@ -440,32 +434,31 @@ int W32_CALL poll (struct pollfd *p, int num, int timeout_ms)
       ++ret;
     }
 
-    /* Poll for caught signals (SIGINT/SIGALRM)
-     */
-    if (_sock_sig_pending())
-       goto poll_intr;
-
     if (ret || timeout_ms == 0)
     {
       SOCK_DEBUGF ((", ret=%d", ret));
-      goto poll_ok;
+      break;
     }
 
     if (timeout_ms > 0 && chk_timeout (timeout_at))
     {
       SOCK_DEBUGF ((", timeout!"));
-      goto poll_ok;
+      break;
+    }
+
+    /* Poll for caught signals (SIGINT/SIGALRM)
+     */
+    if (_sock_sig_pending())
+    {
+      SOCK_DEBUGF ((", EINTR"));
+      SOCK_ERRNO (EINTR);
+      ret = -1;
+      break;
     }
 
     WATT_YIELD();
   }
 
-poll_intr:
-  SOCK_DEBUGF ((", EINTR"));
-  SOCK_ERRNO (EINTR);
-  ret = -1;
-
-poll_ok:
   _sock_sig_restore();
 
   return (ret);

--- a/src/select.c
+++ b/src/select.c
@@ -252,20 +252,6 @@ int W32_CALL select_s (int nfds, fd_set *readfds, fd_set *writefds,
 
     } /* end of for loop; all sockets checked at least once */
 
-    /* WATT_YIELD() sometimes hangs for approx 250msec under Win-XP.
-     * Don't yield for "small" timeouts.
-     */
-#if (!ALWAYS_YIELD)
-    if (!timeout || timercmp(timeout,&sel_min_block,>))
-#endif
-    {
-      if (ret_count == 0)
-      {
-        WATT_YIELD();
-        tcp_tick (NULL);
-      }
-    }
-
     if (timeout)
     {
       gettimeofday2 (&now, NULL);
@@ -355,6 +341,16 @@ int W32_CALL select_s (int nfds, fd_set *readfds, fd_set *writefds,
       SOCK_ERRNO (EINTR);
       ret_count = -1;
       break;
+    }
+
+    /* WATT_YIELD() sometimes hangs for approx 250msec under Win-XP.
+     * Don't yield for "small" timeouts.
+     */
+#if (!ALWAYS_YIELD)
+    if (!timeout || timercmp(timeout,&sel_min_block,>))
+#endif
+    {
+      WATT_YIELD();
     }
   }
 


### PR DESCRIPTION
Some more tweaks to `poll()`/`select_s()`:

* If we get interrupted by a signal, but already have one or more ready sockets, that should not be an error.
* Yield should happen at the end of a loop (only if there is no reason to return yet). Also, no need to `tcp_tick()` twice in one loop.
* Then, I think the short-timeout hack for WinXP can be removed.  If yield does stall, then the next loop will return some result.
