### PR TITLE
Speed up DHCP bootstrap

### DIFF
--- a/src/pcdhcp.c
+++ b/src/pcdhcp.c
@@ -1153,6 +1153,8 @@ int DHCP_do_boot (void)
     cfg_saved = write_config() > 0;
     if (!DAEMON_ADD (dhcp_fsm)) /* add "background" daemon */
        return (0);
+
+    putc('\n', stderr);
     return (1);
   }
   return (0);

--- a/src/pcdhcp.c
+++ b/src/pcdhcp.c
@@ -1024,8 +1024,6 @@ static void W32_CALL dhcp_fsm (void)
           __FUNCTION__, DWORD_CAST(send_timeout), state_name());
 #endif
 
-  WATT_YIELD();
-
   if (sock_dataready(sock))
   {
     int len = sock_fastread (sock, (BYTE*)&dhcp_in, sizeof(dhcp_in));
@@ -1143,6 +1141,8 @@ int DHCP_do_boot (void)
       if (now > timeout)                /* timeout reached */
          break;
     }
+
+    WATT_YIELD();
   }
 
   got_offer = FALSE;   /* ready for next cycle */

--- a/src/pcdhcp.c
+++ b/src/pcdhcp.c
@@ -1110,8 +1110,6 @@ int DHCP_do_boot (void)
   discover_loops = 0;
 
   erase_config();            /* delete old configuration */
-  if(!DAEMON_ADD (dhcp_fsm)) /* add "background" daemon */
-    return (0);
 
 #if 0
   /* kick start DISCOVER message after 100 msec.
@@ -1133,6 +1131,8 @@ int DHCP_do_boot (void)
   while (DHCP_state != DHCP_state_BOUND)
   {
     tcp_tick (NULL);
+    dhcp_fsm ();
+
     if (discover_loops >= max_retries)  /* retries exhaused */
        break;
 
@@ -1151,6 +1151,8 @@ int DHCP_do_boot (void)
   if (my_ip_addr)
   {
     cfg_saved = write_config() > 0;
+    if (!DAEMON_ADD (dhcp_fsm)) /* add "background" daemon */
+       return (0);
     return (1);
   }
   return (0);


### PR DESCRIPTION
Was looking into the DHCP issue (#4) and noticed this potential improvement (that you already hinted at).  While waiting for a DHCP response, we can call `dhcp_fsm()` directly, and then later install it as a daemon for lease renewal.  On my network, this speeds up DHCP configuration from ~4 seconds to almost-instantaneous.

This may appear to "fix" #4, but does not solve the underlying issue (that daemon processes seemingly won't run on 16-bit).
