### PR TITLE
Fix daemon timer

### DIFF
--- a/src/run.c
+++ b/src/run.c
@@ -273,8 +273,8 @@ int daemon_run (void)
           r->running = FALSE;
           rc++;
         }
+    daemon_timer = set_timeout (DAEMON_PERIOD);
   }
-  daemon_timer = set_timeout (DAEMON_PERIOD);
   return (rc);
 }
 


### PR DESCRIPTION
Found the DHCP/daemon problem.  The timer was being reset every time `daemon_run()` was called, and therefore would never actually trigger.

What I don't understand, is why this only caused problems on 16-bit systems...

Fixes: #4
