### PR TITLE
Return partial byte count on error in scatter/gather IO functions

### DIFF
--- a/src/receive.c
+++ b/src/receive.c
@@ -288,7 +288,8 @@ int W32_CALL recvmsg (int s, struct msghdr *msg, int flags)
                    (size_t*)&msg->msg_namelen);
     if (len < 0)
     {
-      bytes = -1;
+      if (bytes == 0)
+         bytes = -1;
       break;
     }
     bytes += len;
@@ -345,7 +346,8 @@ int W32_CALL readv_s (int s, const struct iovec *vector, size_t count)
                    0, NULL, NULL);
     if (len < 0)
     {
-      bytes = -1;
+      if (bytes == 0)
+         bytes = -1;
       break;
     }
     bytes += len;

--- a/src/transmit.c
+++ b/src/transmit.c
@@ -108,7 +108,8 @@ int W32_CALL writev_s (int s, const struct iovec *vector, size_t count)
                     0, NULL, 0, FALSE);
     if (len < 0)
     {
-      bytes = -1;
+      if (bytes == 0)
+         bytes = -1;
       break;
     }
     bytes += len;
@@ -174,7 +175,8 @@ int W32_CALL sendmsg (int s, const struct msghdr *msg, int flags)
                     msg->msg_namelen, TRUE);
     if (len < 0)
     {
-      bytes = -1;
+      if (bytes == 0)
+         bytes = -1;
       break;
     }
     bytes += len;


### PR DESCRIPTION
Just noticed this potential bug.

When reading or writing multiple iovecs, if an error occurs after the first one, the byte count of the previous successful operation is discarded.
In the case of `EWOULDBLOCK`, the application will try again, and will end up sending duplicate output or discarding valid input.  It is safer to return -1 only if nothing was transmitted.
