### PR TITLE
Improve PUSH-bit / flush logic

### DIFF
--- a/inc/sys/socket.h
+++ b/inc/sys/socket.h
@@ -237,6 +237,7 @@ struct sockproto {
 #define MSG_CTRUNC      0x20            /* control data lost before delivery */
 #define MSG_WAITALL     0x40            /* wait for full request or error */
 #define MSG_NOSIGNAL    0x80            /* don't raise SIGPIPE on reset */
+#define MSG_MORE        0x100           /* avoid flush, don't set PUSH bit */
 
 #define MSG_MAXIOVLEN   16
 

--- a/src/tcp_fsm.c
+++ b/src/tcp_fsm.c
@@ -217,7 +217,8 @@ static int tcp_synsent_state (_tcp_Socket **sp, const in_Header *ip,
     if (is_ip4 && ip->tos > s->tos)
        s->tos = ip->tos;
 
-    s->flags   = tcp_FlagACK;
+    s->flags  &= tcp_FlagPUSH;
+    s->flags  |= tcp_FlagACK;
     s->timeout = set_timeout (tcp_TIMEOUT);
 
     /* SYN+ACK means connection established, else SYNREC
@@ -356,7 +357,8 @@ static int tcp_estab_state (_tcp_Socket **sp, const in_Header *ip,
   if (s->send_una < 0)
       s->send_una = 0;
 
-  s->flags = tcp_FlagACK;
+  s->flags &= tcp_FlagPUSH;
+  s->flags |= tcp_FlagACK;
 
   if (is_ip4)
        len = intel16 (ip->length) - in_GetHdrLen (ip);
@@ -430,7 +432,6 @@ static int tcp_estab_state (_tcp_Socket **sp, const in_Header *ip,
                   s->missed_seq[0] != s->missed_seq[1] ?
                   (u_long)(s->missed_seq[0] - s->recv_next) : 0);
       s->karn_count = 0;
-      s->flags |= tcp_FlagPUSH;
       TCP_SEND (s);
       did_tx = TRUE;
 

--- a/src/transmit.c
+++ b/src/transmit.c
@@ -493,8 +493,14 @@ static int tcp_transmit (Socket *socket, const void *buf, unsigned len,
       return (-1);
     }
     if (in_len != len)
-       SOCK_DEBUGF ((" [%u]", len)); /* trace "len=x [y]" */
+    {
+      sk->tcp.sockmode |= SOCK_MODE_LOCAL; /* don't set push bit yet */
+      SOCK_DEBUGF ((" [%u]", len));        /* trace "len=x [y]" */
+    }
   }
+
+  if (sk->tcp.locflags & LF_NOPUSH)
+     sk->tcp.sockmode |= SOCK_MODE_LOCAL;
 
 #if defined(USE_IPV6)
   if (socket->so_family == AF_INET6)

--- a/src/transmit.c
+++ b/src/transmit.c
@@ -104,8 +104,10 @@ int W32_CALL writev_s (int s, const struct iovec *vector, size_t count)
 
   for (i = 0; i < count; i++)
   {
+    int flags = (i + 1 == count ? 0 : MSG_MORE);
+
     len = transmit (NULL, s, vector[i].iov_base, vector[i].iov_len,
-                    0, NULL, 0, FALSE);
+                    flags, NULL, 0, FALSE);
     if (len < 0)
     {
       if (bytes == 0)
@@ -170,8 +172,10 @@ int W32_CALL sendmsg (int s, const struct msghdr *msg, int flags)
 
   for (i = bytes = 0; i < count; i++)
   {
+    int flags2 = flags | (i + 1 == count ? 0 : MSG_MORE);
+
     len = transmit (NULL, s, iov[i].iov_base, iov[i].iov_len,
-                    flags, (struct sockaddr*)msg->msg_name,
+                    flags2, (struct sockaddr*)msg->msg_name,
                     msg->msg_namelen, TRUE);
     if (len < 0)
     {
@@ -215,6 +219,7 @@ static __inline void msg_eor_close (Socket *socket)
  *   MSG_OOB                                           (not supported)
  *   MSG_WAITALL   Wait till room in tx-buffer         (not supported)
  *   MSG_NOSIGNAL  ??                                  (not supported)
+ *   MSG_MORE      Avoid flushing, don't set PUSH bit
  */
 static int transmit (const char *func, int s, const void *buf, unsigned len,
                      int flags, const struct sockaddr *to, int tolen,
@@ -499,7 +504,7 @@ static int tcp_transmit (Socket *socket, const void *buf, unsigned len,
     }
   }
 
-  if (sk->tcp.locflags & LF_NOPUSH)
+  if ((flags & MSG_MORE) || (sk->tcp.locflags & LF_NOPUSH))
      sk->tcp.sockmode |= SOCK_MODE_LOCAL;
 
 #if defined(USE_IPV6)


### PR DESCRIPTION
This patch reduces the number of segments sent with PUSH bit, so that a receiver is more inclined to use delayed-ACK.

Logic:
* There is no need to set a PUSH bit on an empty segment.
* When sending multiple segments, only the last one needs to have PUSH set.
* PUSH bit is automatically enabled on close (if data pending), or retransmit.
* A non-blocking socket does not set PUSH on a partial write.
* Flushing is controlled by `sock_noflush()` or `TCP_NOPUSH`.  If the user does not want to flush yet, we also don't need to set the PUSH bit.
* Once the PUSH bit is enabled, it is only cleared after the whole buffer is flushed.

In addition, we can borrow `MSG_MORE` from Linux to give the BSD interface more control over this.  This is then also used internally to control flushing of multiple iovecs in `sendmsg()`/`writev_s()`.