### PR TITLE
`sendmsg()`/`writev_s()`: Return immediately after partial write

### DIFF
--- a/src/transmit.c
+++ b/src/transmit.c
@@ -113,6 +113,8 @@ int W32_CALL writev_s (int s, const struct iovec *vector, size_t count)
       break;
     }
     bytes += len;
+    if ((unsigned)len != vector[i].iov_len)
+       break;
   }
 
   SOCK_DEBUGF ((", total %d", bytes));  /* writing 0 byte is not an error */
@@ -180,6 +182,8 @@ int W32_CALL sendmsg (int s, const struct msghdr *msg, int flags)
       break;
     }
     bytes += len;
+    if ((unsigned)len != iov[i].iov_len)
+       break;
   }
   SOCK_DEBUGF ((", total %d", bytes));
   return (bytes);


### PR DESCRIPTION
Addition to #101.  After a partial write on a non-blocking socket, we should not try to send the next iovec.  It is very likely that the buffer gets flushed in `tcp_tick()`, and then we end up skipping bytes.  That would be very bad.