### PR TITLE
Fix sign-compare warnings

### DIFF
--- a/src/pctcp.c
+++ b/src/pctcp.c
@@ -3090,7 +3090,7 @@ void W32_CALL sock_flush (sock_type *s)
     _tcp_Socket *tcp = &s->tcp;
 
     tcp->sockmode &= ~SOCK_MODE_LOCAL;
-    if (tcp->tx_datalen > tcp->send_una)
+    if (tcp->tx_datalen > (unsigned long)tcp->send_una)
     {
       tcp->flags |= tcp_FlagPUSH;
       if (s->tcp.send_una == 0)  /* !! S. Lawson - only if data not moving */

--- a/src/tcp_fsm.c
+++ b/src/tcp_fsm.c
@@ -411,7 +411,7 @@ static int tcp_estab_state (_tcp_Socket **sp, const in_Header *ip,
 
   /* Peer ACKed some of our data, continue sending more.
    */
-  if (ldiff > 0 && s->tx_datalen > s->send_una)
+  if (ldiff > 0 && s->tx_datalen > (unsigned long)s->send_una)
      goto send_now;
 
   /* Send ACK for received data.


### PR DESCRIPTION
Introduced in #102 / #103, sorry.

`send_una` should always be positive here, so casting is safe.
