### PR TITLE
Fix 8254 timer inaccuracy

### DIFF
--- a/src/gettod.c
+++ b/src/gettod.c
@@ -462,19 +462,18 @@ int W32_CALL gettimeofday2 (struct timeval *tv, struct timezone *tz)
   if (has_8254)
   {
     static uint64 last = 0;
-    static time_t secs = 0;           /* seconds since midnight */
+    static time_t secs = 0;           /* UTC time() at midnight, local time */
     uint64 usecs = microsec_clock();  /* usec day-clock */
 
     if (secs == 0 || usecs < last)    /* not init or wrapped */
     {
       secs = time (NULL);
-      secs -= (secs % (24*3600));
+      secs -= usecs / 1000000UL;
     }
     last = usecs;
 
     tv->tv_usec = (long) (usecs % U64_SUFFIX(1000000));
     tv->tv_sec = (time_t) ((usecs - tv->tv_usec) / U64_SUFFIX(1000000) + (uint64)secs);
-    tv->tv_sec += utc_offset;
 
     if (tz)
        get_zone (tz, tv->tv_sec);

--- a/src/gettod.c
+++ b/src/gettod.c
@@ -311,7 +311,7 @@ int W32_CALL W32_NAMESPACE (gettimeofday) (struct timeval *tv, struct timezone *
 static __inline uint64 microsec_clock (void)
 {
   DWORD  hi;
-  long   lo;
+  WORD   lo;
   uint64 rc;
 
   do

--- a/src/gettod.c
+++ b/src/gettod.c
@@ -50,8 +50,6 @@
 #include "win_dll.h"
 #include "gettod.h"
 
-#define STEVES_PATCHES 1
-
 #if defined(WIN32)
   #include <sys/timeb.h>
 #else
@@ -463,26 +461,19 @@ int W32_CALL gettimeofday2 (struct timeval *tv, struct timezone *tz)
 
   if (has_8254)
   {
+    static uint64 last = 0;
     static time_t secs = 0;           /* seconds since midnight */
     uint64 usecs = microsec_clock();  /* usec day-clock */
 
-#if STEVES_PATCHES
-    secs = time (NULL);
-#else
-    static uint64 last = 0;
     if (secs == 0 || usecs < last)    /* not init or wrapped */
     {
       secs = time (NULL);
       secs -= (secs % (24*3600));
     }
     last = usecs;
-#endif
+
     tv->tv_usec = (long) (usecs % U64_SUFFIX(1000000));
-#if STEVES_PATCHES
-    tv->tv_sec = (time_t) secs;
-#else
     tv->tv_sec = (time_t) ((usecs - tv->tv_usec) / U64_SUFFIX(1000000) + (uint64)secs);
-#endif
     tv->tv_sec += utc_offset;
 
     if (tz)

--- a/src/gettod.c
+++ b/src/gettod.c
@@ -322,7 +322,7 @@ static __inline uint64 microsec_clock (void)
   while (hi != PEEKL(0, BIOS_CLK));   /* tick count changed, try again */
   lo = 0 - lo;
   rc = ((uint64)hi << 16) + lo;
-  return (rc * U64_SUFFIX(4000000) / U64_SUFFIX(4770000));
+  return (rc * U64_SUFFIX(88000000) / U64_SUFFIX(105000000));
 }
 
 #if (DOSX)

--- a/src/gettod.c
+++ b/src/gettod.c
@@ -472,8 +472,8 @@ int W32_CALL gettimeofday2 (struct timeval *tv, struct timezone *tz)
     }
     last = usecs;
 
-    tv->tv_usec = (long) (usecs % U64_SUFFIX(1000000));
-    tv->tv_sec = (time_t) ((usecs - tv->tv_usec) / U64_SUFFIX(1000000) + (uint64)secs);
+    tv->tv_usec = usecs % 1000000UL;
+    tv->tv_sec = (usecs - tv->tv_usec) / 1000000UL + secs;
 
     if (tz)
        get_zone (tz, tv->tv_sec);

--- a/src/timer.c
+++ b/src/timer.c
@@ -488,7 +488,7 @@ DWORD millisec_clock (void)
   /* Emulating this would be slow. We'd better have a math-processor
    */
   x = ldexp ((double)hi, 16) + (double)lo;  /* x = hi*2^16 + lo */
-  return (DWORD) (x * 4.0 / 4770.0);
+  return (DWORD) (x * (88.0 / 105000.0));
 }
 #endif  /* !W32_NO_8087 */
 #endif  /* __MSDOS__ */


### PR DESCRIPTION
Not sure who Steve is, but he messed up a bit here.

The problem in #99 is that `tv_sec` is set from libc `time()`, while `tv_usec` is set from `microsec_clock()`.  Those two are of course not guaranteed to be synchronized.

Simply putting `#define STEVES_PATCHES 0` is a solution, but removing it altogether makes the code more readable again.

The benchmark (from the other thread) now becomes:
```
hires_timer(0):  3387089559 cycles (avg 45161ns per call)
hires_timer(1):   234681742 cycles (avg  3129ns per call)
USE_RDTSC=1   :    27900545 cycles (avg   372ns per call)
```
