### PR TITLE
Disable `adjust_cpu_clock()` in rdtsc timer

### DIFF
--- a/src/gettod.c
+++ b/src/gettod.c
@@ -460,7 +460,10 @@ int W32_CALL gettimeofday2 (struct timeval *tv, struct timezone *tz)
     tv->tv_sec  = (time_t) ((usecs - tv->tv_usec) / U64_SUFFIX(1000000));
     if (tz)
        get_zone (tz, tv->tv_sec);
-    adjust_cpu_clock (tv);
+
+    /* This has a midnight bug, disabled for now.
+     */
+    /* adjust_cpu_clock (tv); */
     return (0);
   }
 #endif


### PR DESCRIPTION
I was looking to find out how this code works, and see if maybe the `gettimeofday()` call could be replaced with something else.

https://github.com/gvanem/Watt-32/blob/5f72db8e5cfe8e7c701ecc958030b6118af93b6b/src/gettod.c#L363-L399

But it's not clear to me what it's trying to do.  `tick` and `last` are always multiples of 5, so:
```c
corr = abs ((int)last-(int)tick) / 8
     = abs (     10  -     15  ) / 8
     = 5 / 8
     = 0
```
The correction is always zero.  Maybe it does something if you call it less often, say once every second, but that is not how it's used here.  And even then I don't quite see how it relates BIOS ticks to rdtsc ticks.

But then at midnight:
```c
corr = abs ((int)last-(int)tick) / 8
     = abs ( 1573035 -     0   ) / 8
     = 1573035 / 8
     = 196629
```
And it completely breaks.

So I think the safe option for now is to disable this code.
