### PR TITLE
Don't include uio.h on DJGPP v2.3

### DIFF
--- a/inc/sys/wtypes.h
+++ b/inc/sys/wtypes.h
@@ -65,7 +65,7 @@
   #include <sys/version.h>      /* for DJGPP_MINOR */
 #endif
 
-#if defined(__DJGPP__) && !defined(WATT32_DJGPP_MINGW)
+#if (defined(__DJGPP__) && DJGPP_MINOR >= 4) && !defined(WATT32_DJGPP_MINGW)
   #include <sys/uio.h>          /* for struct iovec */
   #define IOVEC_DEFINED
 #endif


### PR DESCRIPTION
#75 added `#include <sys/uio.h>` to the DJGPP build of the project. Unfortunately this made the build of DJGPP that ships with FreeDOS 1.3 and SVarDOS fail to build Watt-32 as that header doesn't exist in those versions.

Since the DOS versions of DJGPP identifies as v2.3 and the [gcc12 based cross compiler](https://github.com/andrewwutw/build-djgpp/releases/tag/v3.4) identifies as version 2.5 the quick fix to get building working on DOS again is to check what minor version of DJGPP is being used and fallback when minor version is <= 3.