### PR TITLE
Use sprintf to make codebase C89 compliant

### DIFF
--- a/src/cpuid.c
+++ b/src/cpuid.c
@@ -1,6 +1,6 @@
 /*
  * CPU-model tool. Uses CPUID to figure out a more
- * excact name of the running processor. Supports these 32 and 64-bit
+ * exact name of the running processor. Supports these 32 and 64-bit
  * CPUs:
  *   GenuineIntel, AuthenticAMD and CentaurHauls.
  *
@@ -274,7 +274,7 @@ const char *cpu_get_model (void)
 
   id_max = GET_CPUID2 (0, vendor_str2);
 
-  snprintf (vendor_str, sizeof(vendor_str), "%.4s%.4s%.4s",
+  sprintf (vendor_str, "%.4s%.4s%.4s",
             vendor_str2,      /* EBX */
             vendor_str2+4+4,  /* EDX */
             vendor_str2+4);   /* ECX */
@@ -323,7 +323,7 @@ const char *cpu_get_freq_info1 (void)
   ebx = *(DWORD*) &info [1];
   ecx = *(DWORD*) &info [2];
 
-  snprintf (result, sizeof(result), "Core base: %lu, Core max: %lu, Core bus: %lu (MHz)",
+  sprintf (result, "Core base: %lu, Core max: %lu, Core bus: %lu (MHz)",
             eax & (1 << 15), ebx & (1 << 15), ecx & (1 << 15));
   return (result);
 }
@@ -341,7 +341,7 @@ const char *cpu_get_freq_info2 (void)
   GET_CPUID2 (0x80000007, info);
   edx = *(DWORD*) &info [3];
 
-  snprintf (result, sizeof(result), "EDX: 0x%08lX, FID: %lu, EffFreqRO: %lu, ProcFeedback: %lu",
+  sprintf (result, "EDX: 0x%08lX, FID: %lu, EffFreqRO: %lu, ProcFeedback: %lu",
             edx, (edx & 1), (edx & (1 << 10)), (edx & (1 << 11)));
   return (result);
 }
@@ -362,7 +362,7 @@ const char *cpu_get_brand_info (void)
   eax [1] = GET_CPUID2 (0x80000003, info2);
   eax [2] = GET_CPUID2 (0x80000004, info3);
 
-  snprintf (result, sizeof(result),
+  sprintf (result,
             "%.4s%.12s" "%.4s%.12s" "%.4s%.12s",
             (const char*) &eax[0], info1,
             (const char*) &eax[1], info2,

--- a/src/cpuid.c
+++ b/src/cpuid.c
@@ -311,7 +311,7 @@ const char *cpu_get_model (void)
 
 const char *cpu_get_freq_info1 (void)
 {
-  static char  result [100];
+  static char  result [102];
   char   info [13];
   DWORD  id_max = GET_CPUID2 (0, info);
   DWORD  eax = 0, ebx = 0, ecx = 0;
@@ -330,7 +330,7 @@ const char *cpu_get_freq_info1 (void)
 
 const char *cpu_get_freq_info2 (void)
 {
-  static char  result [100];
+  static char  result [112];
   char   info [13];
   DWORD  id_max = GET_CPUID2 (0x80000007, info);
   DWORD  edx;
@@ -353,7 +353,7 @@ const char *cpu_get_brand_info (void)
   char   info3 [13];
   DWORD  id_max = GET_CPUID2 (0x80000000, NULL);
   DWORD  eax [3];
-  static char result [100];
+  static char result [49];
 
   if (id_max < 0x80000004)
      return (NULL);

--- a/src/cpuid.c
+++ b/src/cpuid.c
@@ -309,6 +309,7 @@ const char *cpu_get_model (void)
   return (NULL);
 }
 
+#if 0
 const char *cpu_get_freq_info1 (void)
 {
   static char  result [102];
@@ -345,6 +346,7 @@ const char *cpu_get_freq_info2 (void)
             edx, (edx & 1), (edx & (1 << 10)), (edx & (1 << 11)));
   return (result);
 }
+#endif
 
 const char *cpu_get_brand_info (void)
 {

--- a/src/pcdbug.c
+++ b/src/pcdbug.c
@@ -2243,7 +2243,7 @@ static void dbug_dump (const void *sock, const in_Header *ip,
      dbug_putc ('\n');   /* !! Why do I need this? */
 
   if (dbg_print_size)    /* debug.rx_size = 1 */
-       snprintf (sz_buf, sizeof(sz_buf), ", size %u",
+       sprintf (sz_buf, ", size %u",
                  out ? _eth_last.tx.size : _eth_last.rx.size);
   else sz_buf [0] = '\0';
 

--- a/src/pcdbug.c
+++ b/src/pcdbug.c
@@ -2179,7 +2179,7 @@ static void dbug_dump (const void *sock, const in_Header *ip,
                        const char *fname, unsigned line, BOOL out)
 {
   static BOOL print_once = FALSE;
-  char   sz_buf [30];
+  char   sz_buf [28];
   int    err;
 
   WATT_ASSERT (ip);


### PR DESCRIPTION
As discussed in #120 this PR replaces instances of `snprintf` with `sprintf` in `cpuid.c` and `pcdbug.c` which allows C89 compilers and linkers without their own `snprintf` extensions to build the library again.

Additionally maximum length these `sprintf` calls can output has been hand calculated and array size adjusted accordingly, resulting in a tiny amount of more free memory.