### PR TITLE
Explicitly strip out unused static function 'adjust_cpu_clock'

### DIFF
--- a/src/gettod.c
+++ b/src/gettod.c
@@ -360,6 +360,8 @@ static uint64 tsc_microsec (const uint64 *base)
   return (rc);
 }
 
+/* This function has a midnight bug, disabled for now.*/
+#if 0
 static void adjust_cpu_clock (const struct timeval *tv)
 {
   static DWORD last = 0;
@@ -397,6 +399,7 @@ static void adjust_cpu_clock (const struct timeval *tv)
     last = tick;
   }
 }
+#endif
 
 /*
  * Return a 'timeval' from a CPU timestamp.


### PR DESCRIPTION
Addresses unused function part of #120 report. Function `adjust_cpu_clock` has been disabled due to a midnight bug. Manually stripping out the function with pre-processor commands removes the warning but keeps the source code available in case someone ever wants to fix it.