### PR TITLE
Refactored strltrim so VALID_CH() macro dosen't generate any warnings

### DIFF
--- a/src/misc_str.c
+++ b/src/misc_str.c
@@ -249,10 +249,16 @@ char *_strlcpy (char *dst, const char *src, size_t len)
  */
 char *strltrim (const char *s)
 {
+  int ch;
   WATT_ASSERT (s != NULL);
 
-  while (s[0] && s[1] && VALID_CH((int)s[0]) && ISSPACE(s[0]))
-       s++;
+  while (s[0] && s[1])
+  {
+    ch = s[0];
+    if (VALID_CH(ch) && ISSPACE(ch))
+      break;
+    s++;
+  }
   return (char*)s;
 }
 


### PR DESCRIPTION
Resolves the type-limits warning in #120 

What DJGPP is saying here makes sense. `VALID_CH` is a macro inclining  `((c) >= -1 && (c) <= 255)` but a `char` can never go higher than `128` while `-1` and `255` are the same on an `unsigned char` the whole test seems redundant, never the less copying the `char` to an `int` as is done in the other `str*` functions silences this error.