### PR TITLE
Fixed array-bounds warnings on DJGPP

### DIFF
--- a/src/pcdns.c
+++ b/src/pcdns.c
@@ -493,8 +493,7 @@ static int lookup_domain (
        BOOL              is_aaaa,       /* Query A or AAAA record */
        void             *addr)          /* return address */
 {
-  _udp_Socket sock;
-  sock_type  *dom_sock = NULL;
+  sock_type  sock, *dom_sock = NULL;
 
   struct DNS_query reply;
   char   namebuf [3*MAX_HOSTLEN]; /* may overflow!! */
@@ -570,7 +569,7 @@ static int lookup_domain (
          id_cache [id_index++] = q->head.ident;
     else outsnl (_LANG("udp_dom(): ID cache full"));
 
-    dom_sock = (sock_type*) &sock;
+    dom_sock = &sock;
 
     if (!send_query(dom_sock, q, namebuf, nameserver, qtype))
     {

--- a/src/udp_rev.c
+++ b/src/udp_rev.c
@@ -105,8 +105,7 @@ static BOOL reverse_lookup (const struct DNS_query *q, size_t qlen,
   BOOL        quit  = FALSE;
   WORD        sec;
   DWORD       timer;
-  _udp_Socket dom_sock;
-  sock_type  *sock = NULL;
+  sock_type   dom_sock, *sock = NULL;
 
   if (!nameserver)      /* no nameserver, give up */
   {
@@ -115,7 +114,7 @@ static BOOL reverse_lookup (const struct DNS_query *q, size_t qlen,
     return (FALSE);
   }
 
-  if (!udp_open(&dom_sock, DOM_SRC_PORT, nameserver, DOM_DST_PORT, NULL))
+  if (!udp_open(&dom_sock.udp, DOM_SRC_PORT, nameserver, DOM_DST_PORT, NULL))
   {
     dom_errno = DNS_CLI_SYSTEM;
     return (FALSE);
@@ -125,7 +124,7 @@ static BOOL reverse_lookup (const struct DNS_query *q, size_t qlen,
 
   for (sec = 2; sec < dns_timeout-1 && !quit && !_resolve_exit; sec *= 2)
   {
-    sock = (sock_type*)&dom_sock;
+    sock = &dom_sock;
     sock_write (sock, (const BYTE*)q, qlen);
     ip_timer_init (sock, sec);               /* per server expiry */
 


### PR DESCRIPTION
Fixes part of #120 the issue was caused by casts to a union pointer pointing to one of it's members the fix was to simplify the code by declaring both the pointer and stack variable as the union type `sock_type`. 

These changes haven't been tested but in theory should result in the exact same output